### PR TITLE
Fix: remove CryptographyDeprecationWarnings and add string output for Python 3

### DIFF
--- a/tools/encrypted_queries_tools-p3.py
+++ b/tools/encrypted_queries_tools-p3.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.kdf import x963kdf
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.ciphers import Cipher,algorithms,modes
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 import base64
 import base58
 import codecs
@@ -19,8 +20,7 @@ decode_hex = codecs.getdecoder("hex_codec")
 def hex_to_key(pub_key_hex):
     pub_key_hex = pub_key_hex.strip()
     pub_key_point = decode_hex(pub_key_hex)[0]
-    public_numbers = ec.EllipticCurvePublicNumbers.from_encoded_point(ec.SECP256K1(), pub_key_point)
-    public_key = public_numbers.public_key(backend)
+    public_key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), pub_key_point)
     return public_key
 
 def hex_to_priv_key(priv_key_hex, public_key_hex):
@@ -44,7 +44,7 @@ def encrypt(message, receiver_public_key):
     sender_private_key = ec.generate_private_key(ec.SECP256K1(), backend)
     shared_key = sender_private_key.exchange(ec.ECDH(), receiver_public_key)
     sender_public_key = sender_private_key.public_key()
-    point = sender_public_key.public_numbers().encode_point()
+    point = sender_public_key.public_bytes(serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint)
     iv = '000000000000'.encode()
     xkdf = x963kdf.X963KDF(
         algorithm = hashes.SHA256(),

--- a/tools/encrypted_queries_tools-p3.py
+++ b/tools/encrypted_queries_tools-p3.py
@@ -24,7 +24,7 @@ def hex_to_key(pub_key_hex):
     return public_key
 
 def hex_to_priv_key(priv_key_hex, public_key_hex):
-    priv_key_value = long(priv_key_hex, 16)
+    priv_key_value = int(priv_key_hex, 16)
     public_key = hex_to_key(public_key_hex)
     public_numbers = public_key.public_numbers()
     private_numbers = ec.EllipticCurvePrivateNumbers(priv_key_value, public_numbers)
@@ -75,14 +75,14 @@ def decrypt(message, receiver_private_key):
         length = 32,
         sharedinfo = ''.encode(),
         backend = backend
-        )
+    )
     key = xkdf.derive(shared_key)
     decryptor = Cipher(
         algorithms.AES(key),
         modes.GCM(iv,tag),
         backend = backend
-        ).decryptor()
-    message = decryptor.update(ciphertext.encode()) +  decryptor.finalize()
+    ).decryptor()
+    message = decryptor.update(ciphertext) +  decryptor.finalize()
     return message
 
 
@@ -110,10 +110,10 @@ def main():
             pub_key = hex_to_key(args.public_key)
 
         if args.text:
-            print(base64.b64encode(encrypt(args.text, pub_key)))
+            print(base64.b64encode(encrypt(args.text, pub_key)).decode('utf-8'))
             return
         else:
-            print(base64.b64encode(encrypt(sys.stdin.read(), pub_key)))
+            print(base64.b64encode(encrypt(sys.stdin.read(), pub_key)).decode('utf-8'))
             return
     elif args.mode == 'decrypt':
         if args.text:

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
-cryptography
+cryptography==2.4.2
 base58

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
-cryptography==2.4.2
+cryptography
 base58


### PR DESCRIPTION
Fixes #5 

## 📯 Fix:

* The fixed cryptography requirement avoids CryptographyDeprecationWarnings
* The `long()` method is no more present in python3 and was leading to an error, replaced with `int()`
* The output is now given as a string instead of bytearray 

---

Please, @D-Nice could you review the code?

## ✒️ Notes:

- Tested successfully both the p2 and p3 tools, they results in the same output given the same input. They can be used interchangeably. 
- Tested successfully both encrypt and decrypt functions. 
- Tested successfully also w/ our api endpoint.